### PR TITLE
Pydantic backwards compatibility with Python < 3.10

### DIFF
--- a/src/tuspyserver/params.py
+++ b/src/tuspyserver/params.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Hashable
 
 from pydantic import BaseModel

--- a/src/tuspyserver/params.py
+++ b/src/tuspyserver/params.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Hashable
+from typing import Hashable, Optional, Union
 
 from pydantic import BaseModel
 
@@ -13,5 +11,5 @@ class TusUploadParams(BaseModel):
     created_at: str
     defer_length: bool = False
     upload_chunk_size: int = 0
-    expires: float | str | None
-    error: str | None = None
+    expires: Optional[Union[float, str]]
+    error: Optional[str] = None

--- a/src/tuspyserver/router.py
+++ b/src/tuspyserver/router.py
@@ -12,11 +12,11 @@ class TusRouterOptions(BaseModel):
     prefix: str
     files_dir: str
     max_size: int
-    auth: Callable[[], None] | None
+    auth: Optional[Callable[[], None]]
     days_to_keep: int
-    on_upload_complete: Callable[[str, dict], None] | None
-    upload_complete_dep: Callable[..., Callable[[str, dict], None]] | None
-    tags: list[str] | None
+    on_upload_complete: Optional[Callable[[str, dict], None]]
+    upload_complete_dep: Optional[Callable[..., Callable[[str, dict], None]]]
+    tags: Optional[list[str]]
     tus_version: str
     tus_extension: str
 


### PR DESCRIPTION
The use of the | operator for Pydantic was introduced with Python 3.10.
This PR reverts to the Option[Union] pattern for backward compatability.

Code is importable, but no runtime validation has been made - so be warned.