### PR TITLE
Add file_dep for dynamic file uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ tus_router = create_tus_router(
     upload_complete_dep=None,             # upload callback (dependency injector)
     pre_create_hook=None,                 # pre-creation callback
     pre_create_dep=None,                  # pre-creation callback (dependency injector)
+    file_dep=None,                        # file path callback (dependency injector)
 )
 ```
 
@@ -209,6 +210,40 @@ def validate_user_upload(
 app.include_router(
     create_tus_router(
         pre_create_dep=validate_user_upload,
+    )
+)
+```
+
+#### File Routing Dependency Injection
+
+You can use dependency injection with file dep for directly storing the file:
+
+```python
+from fastapi import Depends, HTTPException
+from your_app.dependencies import get_db, get_current_user, get_user_dir
+
+def get_file(
+    db=Depends(get_db),
+    current_user=Depends(get_current_user),
+) -> Callable[[dict, dict], None]:
+    # callback function
+    async def handler(metadata: dict):
+        # Get the file name
+        file_name = metadata["file_name"]
+        # Get the file directory
+        file_dir = get_user_dir(current_user)
+
+        return {
+            "file_dir": file_dir,
+            "uid": file_name
+        }
+
+    return handler
+
+# Include router with the pre-create DI hook
+app.include_router(
+    create_tus_router(
+        file_dep=file_dep,
     )
 )
 ```

--- a/src/tuspyserver/file.py
+++ b/src/tuspyserver/file.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 import typing
 from typing import List, Optional
 
@@ -34,6 +35,8 @@ class TusUploadFile:
         else:
             # reading existing file
             self.uid = uid
+            if not self.exists:
+                self.create()
         # create the files dir if necessary
         if not os.path.exists(self._options.files_dir):
             os.makedirs(self._options.files_dir)

--- a/src/tuspyserver/routes/creation.py
+++ b/src/tuspyserver/routes/creation.py
@@ -85,8 +85,9 @@ def creation_extension_routes(router, options):
         result = pre_create(metadata, upload_info)
         # if the callback returned a coroutine, await it
         if inspect.isawaitable(result):
-            await result
-
+            result = await result
+        if isinstance(result, dict):
+            options.files_dir = result.get("files_dir", options.files_dir)
         # create the file
         file = TusUploadFile(options=options, params=params)
         # update request headers


### PR DESCRIPTION
Using tuspyserver is slow when you want routing to a file path directly, especially if you are using it in a service which allows users to upload their files and you would want to store files for each user separately.

This adds a new dep based option named `file_dep` which allows server to set the file directory and path based on a dependency (probably the user).

I have tested this with multiple concurrent uploads with large files, and it works nicely. Open to comments and suggestions!