### PR TITLE
fix(lock): bound flock with timeout, publish 4.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ tus_router = create_tus_router(
     upload_complete_dep=None,             # upload callback (dependency injector)
     pre_create_hook=None,                 # pre-creation callback
     pre_create_dep=None,                  # pre-creation callback (dependency injector)
+    file_dep=None,                        # file path callback (dependency injector)
 )
 ```
 
@@ -209,6 +210,40 @@ def validate_user_upload(
 app.include_router(
     create_tus_router(
         pre_create_dep=validate_user_upload,
+    )
+)
+```
+
+#### File Routing Dependency Injection
+
+You can use dependency injection with file dep for directly storing the file:
+
+```python
+from fastapi import Depends, HTTPException
+from your_app.dependencies import get_db, get_current_user, get_user_dir
+
+def get_file(
+    db=Depends(get_db),
+    current_user=Depends(get_current_user),
+) -> Callable[[dict, dict], None]:
+    # callback function
+    async def handler(metadata: dict):
+        # Get the file name
+        file_name = metadata["file_name"]
+        # Get the file directory
+        file_dir = get_user_dir(current_user)
+
+        return {
+            "file_dir": file_dir,
+            "uid": file_name
+        }
+
+    return handler
+
+# Include router with the pre-create DI hook
+app.include_router(
+    create_tus_router(
+        file_dep=file_dep,
     )
 )
 ```

--- a/example/backend/server.py
+++ b/example/backend/server.py
@@ -36,13 +36,13 @@ def pre_create_hook(metadata: dict, upload_info: dict):
     if "filename" not in metadata:
         raise HTTPException(status_code=400, detail="Filename is required")
 
-    # Example: Check file size limits (100MB)
-    if upload_info["size"] and upload_info["size"] > 100_000_000:
-        raise HTTPException(status_code=413, detail="File too large (max 100MB)")
+    # Example: Check file size limits (1GB)
+    if upload_info["size"] and upload_info["size"] > 1_000_000_000:
+        raise HTTPException(status_code=413, detail="File too large (max 1GB)")
 
     # Example: Validate file type if provided
     if "filetype" in metadata:
-        allowed_types = ["image/jpeg", "image/png", "application/pdf", "text/plain"]
+        allowed_types = ["image/jpeg", "image/png", "application/pdf", "text/plain", "video/mp4", "audio/mp3", "audio/mpeg"]
         if metadata["filetype"] not in allowed_types:
             raise HTTPException(
                 status_code=400, detail=f"File type {metadata['filetype']} not allowed"
@@ -62,6 +62,7 @@ def on_upload_complete(file_path: str, metadata: dict):
 app.include_router(
     create_tus_router(
         files_dir="./uploads",
+        max_size=1_000_000_000,  # 1GB (10x increase from 100MB)
         pre_create_hook=pre_create_hook,
         on_upload_complete=on_upload_complete,
         prefix="files",

--- a/example/frontend/index.html
+++ b/example/frontend/index.html
@@ -14,7 +14,7 @@
   <div id="drag-drop-area"></div>
 
   <script type="module">
-    const url = import.meta.env.VITE_BACKEND_URL ?? 'http://localhost:8000'
+    const url = 'http://localhost:8000'
     console.log(`Resolved API url: ${url}`)
     import {
       Uppy, Dashboard, Tus
@@ -26,7 +26,7 @@
       })
       .use(Tus, {
         endpoint: `${url}/files/`,
-        chunkSize: 100_000_000, // 100MB
+        chunkSize: 100_000_000_000,
       })
 
     uppy.on('complete', (result) => {

--- a/example/proxy/nginx.conf
+++ b/example/proxy/nginx.conf
@@ -20,6 +20,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
         proxy_cache_bypass $http_upgrade;
 
         # Pass through all headers from the backend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuspyserver"
-version = "4.1.6"
+version = "4.1.7"
 description ="A Python tus server implementation as a FastAPI router"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuspyserver"
-version = "4.2.0"
+version = "4.2.1"
 description ="A Python tus server implementation as a FastAPI router"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuspyserver"
-version = "4.1.8"
+version = "4.1.9"
 description ="A Python tus server implementation as a FastAPI router"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuspyserver"
-version = "4.1.7"
+version = "4.1.8"
 description ="A Python tus server implementation as a FastAPI router"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuspyserver"
-version = "4.1.9"
+version = "4.2.0"
 description ="A Python tus server implementation as a FastAPI router"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuspyserver"
-version = "4.2.1"
+version = "4.2.3"
 description ="A Python tus server implementation as a FastAPI router"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuspyserver"
-version = "4.1.2"
+version = "4.1.3"
 description ="A Python tus server implementation as a FastAPI router"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuspyserver"
-version = "4.1.4"
+version = "4.1.5"
 description ="A Python tus server implementation as a FastAPI router"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuspyserver"
-version = "4.1.5"
+version = "4.1.6"
 description ="A Python tus server implementation as a FastAPI router"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuspyserver"
-version = "4.1.1"
+version = "4.1.2"
 description ="A Python tus server implementation as a FastAPI router"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuspyserver"
-version = "4.1.3"
+version = "4.1.4"
 description ="A Python tus server implementation as a FastAPI router"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tuspyserver"
-version = "4.2.3"
+version = "4.2.4"
 description ="A Python tus server implementation as a FastAPI router"
 readme = "README.md"
 authors = [

--- a/src/tuspyserver/file.py
+++ b/src/tuspyserver/file.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from copy import deepcopy
 import typing
 from typing import List, Optional
 

--- a/src/tuspyserver/file.py
+++ b/src/tuspyserver/file.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 import typing
 from typing import List, Optional
 
@@ -34,6 +35,8 @@ class TusUploadFile:
         else:
             # reading existing file
             self.uid = uid
+            if not self.exists:
+                self.create()
         # create the files dir if necessary
         if not os.path.exists(self._options.files_dir):
             os.makedirs(self._options.files_dir)

--- a/src/tuspyserver/info.py
+++ b/src/tuspyserver/info.py
@@ -14,23 +14,30 @@ from tuspyserver.params import TusUploadParams
 
 class TusUploadInfo:
     _params: Optional[TusUploadParams]
+    _loaded: bool
     file: TusUploadFile
 
     def __init__(self, file: TusUploadFile, params: Optional[TusUploadParams] = None):
         self.file = file
         self._params = params
+        self._loaded = params is not None  # If params provided, consider them loaded
         # create if doesn't exist
         if params and not self.exists:
             self.serialize()
 
     @property
     def params(self):
-        self.deserialize()
+        # Only deserialize if we haven't loaded params yet
+        # This prevents overwriting in-memory params on every access
+        if not self._loaded:
+            self.deserialize()
+            self._loaded = True
         return self._params
 
     @params.setter
     def params(self, value):
         self._params = value
+        self._loaded = True  # Mark as loaded since we're explicitly setting params
         self.serialize()
 
     @property
@@ -42,11 +49,34 @@ class TusUploadInfo:
         return os.path.exists(self.path)
 
     def serialize(self) -> None:
-        with open(self.path, "w") as f:
-            json_string = json.dumps(
-                self._params, indent=4, default=lambda k: k.__dict__
-            )
-            f.write(json_string)
+        """
+        Atomically serialize params to info file.
+        
+        Uses a temporary file and atomic rename to prevent corruption
+        from concurrent writes.
+        """
+        # Write to temporary file first
+        temp_path = f"{self.path}.tmp"
+        try:
+            with open(temp_path, "w") as f:
+                json_string = json.dumps(
+                    self._params, indent=4, default=lambda k: k.__dict__
+                )
+                f.write(json_string)
+                f.flush()
+                # Ensure data is written to disk
+                os.fsync(f.fileno())
+            
+            # Atomic rename - this is atomic on Unix systems
+            os.rename(temp_path, self.path)
+        except Exception:
+            # Clean up temp file if rename fails
+            try:
+                if os.path.exists(temp_path):
+                    os.remove(temp_path)
+            except Exception:
+                pass
+            raise
 
     def deserialize(self) -> Optional[TusUploadParams]:
         if self.exists:

--- a/src/tuspyserver/lock.py
+++ b/src/tuspyserver/lock.py
@@ -1,0 +1,185 @@
+"""
+File locking utilities for tus uploads.
+
+Provides advisory file locking using fcntl (Unix) to prevent race conditions
+during concurrent upload operations. This implementation matches tusd's approach
+by using separate lock files stored in a .locks directory, where each lock file
+contains the PID of the process holding the lock.
+"""
+import fcntl
+import logging
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class FileLock:
+    """
+    Advisory file lock using fcntl (Unix) with separate lock files.
+    
+    Matches tusd's filelocker approach by creating separate .lock files
+    in a .locks directory. Each lock file contains the PID of the process
+    holding the lock, allowing for lock cleanup if a process crashes.
+    """
+    
+    def __init__(self, file_path: str, locks_dir: Optional[str] = None):
+        """
+        Initialize a file lock.
+        
+        Args:
+            file_path: Path to the upload file to lock
+            locks_dir: Directory to store lock files (defaults to {files_dir}/.locks)
+        """
+        self.file_path = file_path
+        self.locks_dir = locks_dir
+        
+        # Derive lock file path from upload file path
+        if locks_dir:
+            # Ensure locks directory exists
+            os.makedirs(locks_dir, exist_ok=True)
+            lock_filename = os.path.basename(file_path) + ".lock"
+            self.lock_file_path = os.path.join(locks_dir, lock_filename)
+        else:
+            # Default: create .locks directory next to upload file
+            upload_dir = os.path.dirname(file_path)
+            locks_dir = os.path.join(upload_dir, ".locks")
+            os.makedirs(locks_dir, exist_ok=True)
+            lock_filename = os.path.basename(file_path) + ".lock"
+            self.lock_file_path = os.path.join(locks_dir, lock_filename)
+        
+        self._lock_fd: Optional[int] = None
+    
+    def acquire(self, blocking: bool = True) -> bool:
+        """
+        Acquire an exclusive lock on the upload file.
+        
+        Creates a separate lock file and applies an exclusive lock on it.
+        The lock file contains the PID of the process holding the lock.
+        This matches tusd's filelocker approach.
+        
+        Args:
+            blocking: If True, block until lock is acquired. If False, return immediately.
+            
+        Returns:
+            True if lock was acquired, False otherwise (only when blocking=False)
+        """
+        try:
+            # Ensure locks directory exists
+            os.makedirs(os.path.dirname(self.lock_file_path), exist_ok=True)
+            
+            # Open the lock file for read-write, create if it doesn't exist
+            # Use O_RDWR to allow both reading and writing
+            # Use O_CREAT to create the file if it doesn't exist
+            self._lock_fd = os.open(self.lock_file_path, os.O_RDWR | os.O_CREAT, 0o644)
+            
+            # Ensure the lock file contains only the current PID before writing
+            try:
+                os.ftruncate(self._lock_fd, 0)
+                os.lseek(self._lock_fd, 0, os.SEEK_SET)
+            except OSError as e:
+                logger.warning(f"Failed to truncate lock file {self.lock_file_path}: {e}")
+
+            # Write PID to lock file (like tusd does)
+            try:
+                pid_str = str(os.getpid()).encode('utf-8')
+                os.write(self._lock_fd, pid_str)
+                os.fsync(self._lock_fd)  # Ensure PID is written to disk
+                # Seek back to beginning for reading
+                os.lseek(self._lock_fd, 0, os.SEEK_SET)
+            except (IOError, OSError) as e:
+                # If writing PID fails, continue anyway - lock is still valid
+                logger.warning(f"Failed to write PID to lock file {self.lock_file_path}: {e}")
+            
+            # Try to acquire exclusive lock (LOCK_EX) on the lock file
+            # If blocking=False, use LOCK_NB (non-blocking)
+            flags = fcntl.LOCK_EX
+            if not blocking:
+                flags |= fcntl.LOCK_NB
+            
+            fcntl.flock(self._lock_fd, flags)
+            return True
+        except (IOError, OSError) as e:
+            # Lock acquisition failed
+            if self._lock_fd is not None:
+                try:
+                    os.close(self._lock_fd)
+                except Exception:
+                    pass
+                self._lock_fd = None
+            
+            if not blocking and e.errno in (11, 35):  # EAGAIN/EWOULDBLOCK
+                return False
+            raise
+    
+    def release(self) -> None:
+        """Release the lock and close the file descriptor."""
+        if self._lock_fd is not None:
+            try:
+                fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
+                os.close(self._lock_fd)
+            except Exception as e:
+                logger.warning(f"Error releasing lock file descriptor: {e}")
+            finally:
+                self._lock_fd = None
+            
+            # Remove the lock file (tusd does this)
+            # Note: We remove the lock file but keep the .locks directory
+            try:
+                if os.path.exists(self.lock_file_path):
+                    os.remove(self.lock_file_path)
+            except Exception as e:
+                logger.warning(f"Error removing lock file {self.lock_file_path}: {e}")
+    
+    def get_fd(self) -> Optional[int]:
+        """
+        Get the file descriptor for the lock file.
+        
+        Returns:
+            File descriptor if lock is acquired, None otherwise
+        """
+        return self._lock_fd
+    
+    def __enter__(self):
+        """Context manager entry."""
+        self.acquire(blocking=True)
+        return self
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit."""
+        self.release()
+
+
+@contextmanager
+def acquire_upload_lock(upload_path: str, locks_dir: Optional[str] = None, blocking: bool = True):
+    """
+    Context manager for acquiring an upload lock.
+    
+    This matches tusd's filelocker pattern by creating separate lock files
+    in a .locks directory. Each lock file contains the PID of the process
+    holding the lock.
+    
+    Args:
+        upload_path: Path to the upload file to lock
+        locks_dir: Directory to store lock files (defaults to {upload_dir}/.locks)
+        blocking: If True, block until lock is acquired
+        
+    Yields:
+        FileLock instance with the locked file descriptor
+        
+    Example:
+        with acquire_upload_lock("/path/to/upload") as lock:
+            # Lock is held via lock file in .locks directory
+            # Lock file contains PID of this process
+            pass
+    """
+    lock = FileLock(upload_path, locks_dir=locks_dir)
+    try:
+        acquired = lock.acquire(blocking=blocking)
+        if not acquired:
+            raise IOError("Could not acquire lock")
+        yield lock
+    finally:
+        lock.release()

--- a/src/tuspyserver/lock.py
+++ b/src/tuspyserver/lock.py
@@ -5,179 +5,224 @@ Provides advisory file locking using fcntl (Unix) to prevent race conditions
 during concurrent upload operations. This implementation matches tusd's approach
 by using separate lock files stored in a .locks directory, where each lock file
 contains the PID of the process holding the lock.
+
+The lock acquisition is bounded by a timeout so a wedged shared filesystem
+(e.g. flapping Azure Files / SMB) cannot hang request workers indefinitely.
+If the lock directory is unwritable (EACCES / EROFS), we fall back to a
+best-effort no-op lock so a single request fails fast instead of dragging
+all workers down.
 """
+import errno
 import fcntl
 import logging
 import os
+import time
 from contextlib import contextmanager
-from pathlib import Path
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 
+# Bounded waits for filesystem operations. Tuned for shared SMB mounts where
+# operations can briefly stall during reconnects, but must never block forever.
+DEFAULT_LOCK_TIMEOUT = 30.0
+LOCK_POLL_INTERVAL = 0.1
+
+_FS_UNWRITABLE_ERRNOS = {errno.EACCES, errno.EPERM, errno.EROFS, errno.ENOSPC}
+
+
+class LockTimeoutError(IOError):
+    """Raised when a lock cannot be acquired within the configured timeout."""
+
+
 class FileLock:
     """
     Advisory file lock using fcntl (Unix) with separate lock files.
-    
+
     Matches tusd's filelocker approach by creating separate .lock files
     in a .locks directory. Each lock file contains the PID of the process
     holding the lock, allowing for lock cleanup if a process crashes.
     """
-    
+
     def __init__(self, file_path: str, locks_dir: Optional[str] = None):
         """
         Initialize a file lock.
-        
+
         Args:
             file_path: Path to the upload file to lock
             locks_dir: Directory to store lock files (defaults to {files_dir}/.locks)
         """
         self.file_path = file_path
         self.locks_dir = locks_dir
-        
+
         # Derive lock file path from upload file path
         if locks_dir:
-            # Ensure locks directory exists
-            os.makedirs(locks_dir, exist_ok=True)
             lock_filename = os.path.basename(file_path) + ".lock"
             self.lock_file_path = os.path.join(locks_dir, lock_filename)
         else:
             # Default: create .locks directory next to upload file
             upload_dir = os.path.dirname(file_path)
-            locks_dir = os.path.join(upload_dir, ".locks")
-            os.makedirs(locks_dir, exist_ok=True)
+            self.locks_dir = os.path.join(upload_dir, ".locks")
             lock_filename = os.path.basename(file_path) + ".lock"
-            self.lock_file_path = os.path.join(locks_dir, lock_filename)
-        
+            self.lock_file_path = os.path.join(self.locks_dir, lock_filename)
+
         self._lock_fd: Optional[int] = None
-    
-    def acquire(self, blocking: bool = True) -> bool:
+        # Set when the underlying filesystem rejected lock-file creation.
+        # Release becomes a no-op so we don't crash on cleanup.
+        self._best_effort: bool = False
+
+    def acquire(
+        self,
+        blocking: bool = True,
+        timeout: float = DEFAULT_LOCK_TIMEOUT,
+    ) -> bool:
         """
         Acquire an exclusive lock on the upload file.
-        
+
         Creates a separate lock file and applies an exclusive lock on it.
         The lock file contains the PID of the process holding the lock.
         This matches tusd's filelocker approach.
-        
-        Args:
-            blocking: If True, block until lock is acquired. If False, return immediately.
-            
-        Returns:
-            True if lock was acquired, False otherwise (only when blocking=False)
-        """
-        try:
-            # Ensure locks directory exists
-            os.makedirs(os.path.dirname(self.lock_file_path), exist_ok=True)
-            
-            # Open the lock file for read-write, create if it doesn't exist
-            # Use O_RDWR to allow both reading and writing
-            # Use O_CREAT to create the file if it doesn't exist
-            self._lock_fd = os.open(self.lock_file_path, os.O_RDWR | os.O_CREAT, 0o644)
-            
-            # Ensure the lock file contains only the current PID before writing
-            try:
-                os.ftruncate(self._lock_fd, 0)
-                os.lseek(self._lock_fd, 0, os.SEEK_SET)
-            except OSError as e:
-                logger.warning(f"Failed to truncate lock file {self.lock_file_path}: {e}")
 
-            # Write PID to lock file (like tusd does)
-            try:
-                pid_str = str(os.getpid()).encode('utf-8')
-                os.write(self._lock_fd, pid_str)
-                os.fsync(self._lock_fd)  # Ensure PID is written to disk
-                # Seek back to beginning for reading
-                os.lseek(self._lock_fd, 0, os.SEEK_SET)
-            except (IOError, OSError) as e:
-                # If writing PID fails, continue anyway - lock is still valid
-                logger.warning(f"Failed to write PID to lock file {self.lock_file_path}: {e}")
-            
-            # Try to acquire exclusive lock (LOCK_EX) on the lock file
-            # If blocking=False, use LOCK_NB (non-blocking)
-            flags = fcntl.LOCK_EX
-            if not blocking:
-                flags |= fcntl.LOCK_NB
-            
-            fcntl.flock(self._lock_fd, flags)
-            return True
-        except (IOError, OSError) as e:
-            # Lock acquisition failed
-            if self._lock_fd is not None:
-                try:
-                    os.close(self._lock_fd)
-                except Exception:
-                    pass
+        Args:
+            blocking: If True, wait up to ``timeout`` seconds for the lock.
+                If False, return immediately when the lock is contended.
+            timeout: Max seconds to wait for the exclusive lock when
+                ``blocking=True``. Bounded so a wedged shared filesystem
+                cannot hang request workers.
+
+        Returns:
+            True if lock was acquired (or running in best-effort mode),
+            False only when ``blocking=False`` and the lock was held
+            elsewhere.
+
+        Raises:
+            LockTimeoutError: ``blocking=True`` and the lock could not be
+                acquired within ``timeout`` seconds.
+            IOError / OSError: unexpected filesystem failure.
+        """
+        # Open the lock file. If the lock directory is unwritable (EACCES on
+        # a flapping SMB share, read-only filesystem, ...), degrade to
+        # best-effort: do not block the request, just proceed without a
+        # cross-process lock. Single-pod correctness still holds via the
+        # per-process Python state above this layer; multi-pod contention on
+        # the same upload UUID is extremely rare in practice.
+        try:
+            os.makedirs(self.locks_dir, exist_ok=True)
+            self._lock_fd = os.open(
+                self.lock_file_path, os.O_RDWR | os.O_CREAT, 0o644
+            )
+        except OSError as e:
+            if e.errno in _FS_UNWRITABLE_ERRNOS:
+                logger.warning(
+                    "Lock dir %s unwritable (%s); proceeding without lock",
+                    self.locks_dir, e,
+                )
+                self._best_effort = True
                 self._lock_fd = None
-            
-            if not blocking and e.errno in (11, 35):  # EAGAIN/EWOULDBLOCK
-                return False
+                return True
             raise
-    
+
+        # Best-effort PID write (purely informational, like tusd).
+        try:
+            os.ftruncate(self._lock_fd, 0)
+            os.lseek(self._lock_fd, 0, os.SEEK_SET)
+            os.write(self._lock_fd, str(os.getpid()).encode("utf-8"))
+            os.lseek(self._lock_fd, 0, os.SEEK_SET)
+        except OSError as e:
+            logger.warning(
+                "Failed to write PID to lock file %s: %s",
+                self.lock_file_path, e,
+            )
+
+        # Acquire exclusive lock. Use non-blocking + polling so we always have
+        # a hard upper bound, even on a misbehaving network filesystem.
+        deadline = time.monotonic() + max(timeout, 0.0) if blocking else None
+        while True:
+            try:
+                fcntl.flock(self._lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                return True
+            except OSError as e:
+                if e.errno not in (errno.EAGAIN, errno.EWOULDBLOCK):
+                    self._close_fd()
+                    raise
+                if not blocking:
+                    self._close_fd()
+                    return False
+                if time.monotonic() >= deadline:
+                    self._close_fd()
+                    raise LockTimeoutError(
+                        f"Timed out after {timeout:.1f}s waiting for lock "
+                        f"{self.lock_file_path}"
+                    )
+                time.sleep(LOCK_POLL_INTERVAL)
+
+    def _close_fd(self) -> None:
+        if self._lock_fd is not None:
+            try:
+                os.close(self._lock_fd)
+            except Exception:
+                pass
+            self._lock_fd = None
+
     def release(self) -> None:
         """Release the lock and close the file descriptor."""
+        if self._best_effort:
+            self._best_effort = False
+            return
         if self._lock_fd is not None:
             try:
                 fcntl.flock(self._lock_fd, fcntl.LOCK_UN)
-                os.close(self._lock_fd)
             except Exception as e:
-                logger.warning(f"Error releasing lock file descriptor: {e}")
-            finally:
-                self._lock_fd = None
-            
-            # Remove the lock file (tusd does this)
-            # Note: We remove the lock file but keep the .locks directory
+                logger.warning("Error unlocking %s: %s", self.lock_file_path, e)
+            self._close_fd()
             try:
                 if os.path.exists(self.lock_file_path):
                     os.remove(self.lock_file_path)
             except Exception as e:
-                logger.warning(f"Error removing lock file {self.lock_file_path}: {e}")
-    
+                logger.warning(
+                    "Error removing lock file %s: %s",
+                    self.lock_file_path, e,
+                )
+
     def get_fd(self) -> Optional[int]:
-        """
-        Get the file descriptor for the lock file.
-        
-        Returns:
-            File descriptor if lock is acquired, None otherwise
-        """
+        """File descriptor for the lock file, or None when unlocked / best-effort."""
         return self._lock_fd
-    
+
     def __enter__(self):
-        """Context manager entry."""
         self.acquire(blocking=True)
         return self
-    
+
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """Context manager exit."""
         self.release()
 
 
 @contextmanager
-def acquire_upload_lock(upload_path: str, locks_dir: Optional[str] = None, blocking: bool = True):
+def acquire_upload_lock(
+    upload_path: str,
+    locks_dir: Optional[str] = None,
+    blocking: bool = True,
+    timeout: float = DEFAULT_LOCK_TIMEOUT,
+):
     """
     Context manager for acquiring an upload lock.
-    
-    This matches tusd's filelocker pattern by creating separate lock files
-    in a .locks directory. Each lock file contains the PID of the process
-    holding the lock.
-    
+
     Args:
-        upload_path: Path to the upload file to lock
-        locks_dir: Directory to store lock files (defaults to {upload_dir}/.locks)
-        blocking: If True, block until lock is acquired
-        
+        upload_path: Path to the upload file to lock.
+        locks_dir: Directory to store lock files (defaults to ``{upload_dir}/.locks``).
+        blocking: If True, wait up to ``timeout`` seconds for the lock.
+        timeout: Max seconds to wait when blocking. Prevents indefinite
+            hangs on misbehaving shared filesystems.
+
     Yields:
-        FileLock instance with the locked file descriptor
-        
-    Example:
-        with acquire_upload_lock("/path/to/upload") as lock:
-            # Lock is held via lock file in .locks directory
-            # Lock file contains PID of this process
-            pass
+        FileLock instance with the locked file descriptor.
+
+    Raises:
+        LockTimeoutError: Could not acquire the lock within ``timeout``.
+        IOError: ``blocking=False`` and the lock is held elsewhere.
     """
     lock = FileLock(upload_path, locks_dir=locks_dir)
     try:
-        acquired = lock.acquire(blocking=blocking)
+        acquired = lock.acquire(blocking=blocking, timeout=timeout)
         if not acquired:
             raise IOError("Could not acquire lock")
         yield lock

--- a/src/tuspyserver/params.py
+++ b/src/tuspyserver/params.py
@@ -1,4 +1,4 @@
-from typing import Dict, Hashable, Optional, Union
+from typing import Dict, Hashable, List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -13,3 +13,6 @@ class TusUploadParams(BaseModel):
     upload_chunk_size: int = 0
     expires: Optional[Union[float, str]]
     error: Optional[str] = None
+    is_partial: bool = False
+    is_final: bool = False
+    partial_uploads: Optional[List[str]] = None

--- a/src/tuspyserver/request.py
+++ b/src/tuspyserver/request.py
@@ -101,11 +101,12 @@ def get_request_headers(request: Request, uuid: str, prefix: str = "files") -> d
     # Check for forwarded headers first (for proxy setups)
     if request.headers.get("X-Forwarded-Proto") is not None:
         proto = request.headers.get("X-Forwarded-Proto")
-    elif request.headers.get("X-Forwarded-Host") is not None:
+    if request.headers.get("X-Forwarded-Host") is not None:
         host = request.headers.get("X-Forwarded-Host")
-    else:
-        # If no forwarded headers, try to detect scheme from request URL
-        # This handles direct HTTPS connections (e.g., Uvicorn with SSL)
+
+    # If no forwarded protocol, try to detect scheme from request URL
+    # This handles direct HTTPS connections (e.g., Uvicorn with SSL)
+    if proto == "http" and not request.headers.get("X-Forwarded-Proto"):
         try:
             # Use request.url.scheme to detect the actual protocol
             if hasattr(request, 'url') and request.url.scheme:

--- a/src/tuspyserver/request.py
+++ b/src/tuspyserver/request.py
@@ -81,6 +81,8 @@ def make_request_chunks_dep(options: TusRouterOptions):
                     # save updated params
                     file.info = new_params
             except ClientDisconnect:
+                # Save the current offset before returning, so resume works correctly
+                file.info = new_params
                 return False
             except Exception as e:
                 # save the error

--- a/src/tuspyserver/request.py
+++ b/src/tuspyserver/request.py
@@ -38,9 +38,9 @@ def make_request_chunks_dep(options: TusRouterOptions):
         if not file.exists or not file.info:
             raise HTTPException(status_code=404, detail="Upload not found")
 
-        # Validate Upload-Offset header matches current file offset
+        # Validate Upload-Offset header matches current file offset (if strict validation is enabled)
         upload_offset = request.headers.get("upload-offset")
-        if upload_offset is not None:
+        if options.strict_offset_validation and upload_offset is not None:
             upload_offset = int(upload_offset)
             if file.info.offset != upload_offset:
                 raise HTTPException(status_code=409, detail="Conflict")

--- a/src/tuspyserver/request.py
+++ b/src/tuspyserver/request.py
@@ -74,6 +74,7 @@ def make_request_chunks_dep(options: TusRouterOptions):
                         )
                     # write chunk otherwise
                     f.write(chunk)
+                    f.flush()  # Ensure data is written to disk immediately
                     # update upload params
                     new_params.offset += len(chunk)
                     new_params.upload_chunk_size = len(chunk)

--- a/src/tuspyserver/request.py
+++ b/src/tuspyserver/request.py
@@ -15,7 +15,7 @@ from fastapi import Depends, HTTPException, Path, Request
 from starlette.requests import ClientDisconnect
 
 from tuspyserver.file import TusUploadFile
-from tuspyserver.lock import acquire_upload_lock
+from tuspyserver.lock import LockTimeoutError, acquire_upload_lock
 
 
 def make_request_chunks_dep(options: TusRouterOptions):
@@ -178,6 +178,10 @@ def make_request_chunks_dep(options: TusRouterOptions):
                     new_params.upload_part += 1
                     # save updated params
                     file.info = new_params
+        except LockTimeoutError as e:
+            # Shared lock dir is contended or wedged. Fail fast so the worker
+            # is freed instead of piling up behind a stuck filesystem.
+            raise HTTPException(status_code=503, detail=str(e))
         except (IOError, OSError) as e:
             # Lock acquisition or file operation failed
             raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")

--- a/src/tuspyserver/router.py
+++ b/src/tuspyserver/router.py
@@ -49,7 +49,7 @@ def create_tus_router(
         return pre_create_hook or (lambda *_: None)
 
     async def _fallback_file_dep() -> Callable[[dict], None]:
-        return file_dep or (lambda metadata: None)
+        return lambda metadata: None
 
     upload_complete_dep = upload_complete_dep or _fallback_on_complete_dep
     pre_create_dep = pre_create_dep or _fallback_pre_create_dep
@@ -67,7 +67,7 @@ def create_tus_router(
         pre_create_hook=pre_create_hook,
         pre_create_dep=pre_create_dep
         or (lambda _: pre_create_hook or (lambda *_: None)),
-        file_dep=file_dep or (lambda _: file_dep or (lambda metadata: None)),
+        file_dep=file_dep,
         tags=tags,
         tus_version="1.0.0",
         tus_extension=",".join(

--- a/src/tuspyserver/router.py
+++ b/src/tuspyserver/router.py
@@ -23,6 +23,7 @@ class TusRouterOptions(BaseModel):
     tags: Optional[List[str]]
     tus_version: str
     tus_extension: str
+    strict_offset_validation: bool
 
 
 async def noop():
@@ -41,6 +42,7 @@ def create_tus_router(
     pre_create_dep: Optional[Callable[..., Callable[[dict, dict], None]]] = None,
     file_dep: Optional[Callable[..., Callable[[dict], None]]] = None,
     tags: Optional[List[str]] = None,
+    strict_offset_validation: bool = False,
 ):
     async def _fallback_on_complete_dep() -> Callable[[str, dict], None]:
         return on_upload_complete or (lambda *_: None)
@@ -79,6 +81,7 @@ def create_tus_router(
                 "termination",
             ]
         ),
+        strict_offset_validation=strict_offset_validation,
     )
 
     clean_prefix = prefix.lstrip("/").rstrip("/")

--- a/src/tuspyserver/router.py
+++ b/src/tuspyserver/router.py
@@ -48,7 +48,7 @@ def create_tus_router(
         return pre_create_hook or (lambda *_: None)
 
     async def _fallback_file_dep() -> Callable[[dict], None]:
-        return file_dep or (lambda *_: None)
+        return file_dep or (lambda metadata: None)
 
     upload_complete_dep = upload_complete_dep or _fallback_on_complete_dep
     pre_create_dep = pre_create_dep or _fallback_pre_create_dep

--- a/src/tuspyserver/router.py
+++ b/src/tuspyserver/router.py
@@ -79,6 +79,7 @@ def create_tus_router(
                 "creation-with-upload",
                 "expiration",
                 "termination",
+                "concatenation",
             ]
         ),
         strict_offset_validation=strict_offset_validation,

--- a/src/tuspyserver/router.py
+++ b/src/tuspyserver/router.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Callable, List, Optional
 
 from fastapi import APIRouter
@@ -66,7 +67,7 @@ def create_tus_router(
         pre_create_hook=pre_create_hook,
         pre_create_dep=pre_create_dep
         or (lambda _: pre_create_hook or (lambda *_: None)),
-        file_dep=file_dep or (lambda _: file_dep or (lambda *_: None)),
+        file_dep=file_dep or (lambda _: file_dep or (lambda metadata: None)),
         tags=tags,
         tus_version="1.0.0",
         tus_extension=",".join(

--- a/src/tuspyserver/routes/core.py
+++ b/src/tuspyserver/routes/core.py
@@ -37,6 +37,11 @@ def core_routes(router, options):
         # validate file
         file = TusUploadFile(uid=uuid, options=file_options)
 
+        # DEBUG: Log file info for troubleshooting
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.info(f"HEAD {uuid}: exists={file.exists}, info={file.info}, file_size={len(file) if file.exists else 0}")
+
         # Check if file exists and has valid info
         if not file.exists or file.info is None:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)

--- a/src/tuspyserver/routes/core.py
+++ b/src/tuspyserver/routes/core.py
@@ -80,6 +80,12 @@ def core_routes(router, options):
         response.headers["Upload-Offset"] = str(file.info.offset)
         response.headers["Cache-Control"] = "no-store"
 
+        # Add Upload-Concat header for concatenation extension
+        if file.info.is_partial:
+            response.headers["Upload-Concat"] = "partial"
+        elif file.info.is_final:
+            response.headers["Upload-Concat"] = "final"
+
         response.status_code = status.HTTP_200_OK
 
         return response

--- a/src/tuspyserver/routes/creation.py
+++ b/src/tuspyserver/routes/creation.py
@@ -4,6 +4,7 @@ import inspect
 import os
 from datetime import datetime, timedelta
 from typing import Callable
+from urllib.parse import urlparse
 
 from fastapi import Depends, Header, HTTPException, Request, Response, status
 
@@ -24,6 +25,7 @@ def creation_extension_routes(router, options):
         upload_metadata: str = Header(None),
         upload_length: int = Header(None),
         upload_defer_length: int = Header(None),
+        upload_concat: str = Header(None),
         _=Depends(options.auth),
         on_complete: Callable[[str, dict], None] = Depends(options.upload_complete_dep),
         pre_create: Callable[[dict, dict], None] = Depends(options.pre_create_dep),
@@ -66,15 +68,142 @@ def creation_extension_routes(router, options):
                         status_code=400, detail="Unexpected format in metadata"
                     )
 
+        # Handle Upload-Concat header for concatenation extension
+        is_partial = False
+        is_final = False
+        partial_uploads = None
+        final_size = upload_length
+
+        if upload_concat is not None:
+            upload_concat = upload_concat.strip()
+
+            if upload_concat == "partial":
+                # This is a partial upload
+                is_partial = True
+
+            elif upload_concat.startswith("final;"):
+                # This is a final upload created by concatenating partials
+                is_final = True
+
+                # Parse the list of partial upload URLs/UUIDs
+                concat_spec = upload_concat[6:].strip()  # Remove "final;" prefix
+                if not concat_spec:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Upload-Concat final header must specify partial uploads"
+                    )
+
+                # Split by space to get individual URLs/UUIDs
+                partial_url_list = [u.strip() for u in concat_spec.split() if u.strip()]
+                if not partial_url_list:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Upload-Concat final header must specify at least one partial upload"
+                    )
+
+                # Extract UUIDs from URLs or use bare UUIDs
+                partial_uids = []
+                for url_or_uid in partial_url_list:
+                    if url_or_uid.startswith("http://") or url_or_uid.startswith("https://"):
+                        # Parse URL to extract UUID
+                        parsed = urlparse(url_or_uid)
+                        path_parts = [p for p in parsed.path.split("/") if p]
+                        if not path_parts:
+                            raise HTTPException(
+                                status_code=400,
+                                detail=f"Invalid URL in Upload-Concat header: {url_or_uid}"
+                            )
+                        uid = path_parts[-1]
+                    else:
+                        # Assume it's a bare UUID
+                        uid = url_or_uid
+                    partial_uids.append(uid)
+
+                partial_uploads = partial_uids
+
+                # Get the file_options to use for loading partials (call file_dep once, not in loop)
+                # All partials should be in the same directory as the final upload (same user)
+                file_result_for_partials = file_dep(metadata)
+                file_options_for_partials = deepcopy(options)
+                if inspect.isawaitable(file_result_for_partials):
+                    file_result_for_partials = await file_result_for_partials
+                if isinstance(file_result_for_partials, dict):
+                    file_options_for_partials.files_dir = file_result_for_partials.get("files_dir", options.files_dir)
+
+                # Validate and load all partial uploads
+                partial_files = []
+                total_size = 0
+
+                for uid in partial_uids:
+                    # Load the partial upload from the same directory
+                    partial_file = TusUploadFile(options=file_options_for_partials, uid=uid)
+
+                    if not partial_file.exists:
+                        raise HTTPException(
+                            status_code=404,
+                            detail=f"Partial upload not found: {uid}"
+                        )
+
+                    if partial_file.info is None:
+                        raise HTTPException(
+                            status_code=400,
+                            detail=f"Partial upload has no metadata: {uid}"
+                        )
+
+                    # Validate it's marked as partial
+                    if not partial_file.info.is_partial:
+                        raise HTTPException(
+                            status_code=400,
+                            detail=f"Upload {uid} is not a partial upload"
+                        )
+
+                    # Validate it's complete (production-ready validation)
+                    if partial_file.info.size is not None:
+                        if partial_file.info.offset != partial_file.info.size:
+                            raise HTTPException(
+                                status_code=400,
+                                detail=f"Partial upload {uid} is not complete (offset={partial_file.info.offset}, size={partial_file.info.size})"
+                            )
+
+                    # Get actual file size
+                    file_size = len(partial_file)
+                    total_size += file_size
+                    partial_files.append(partial_file)
+
+                # Final upload size is the sum of all partials
+                final_size = total_size
+
+                # Upload-Length is forbidden for final uploads (we calculate it)
+                if upload_length is not None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Upload-Length header must not be included for final concatenated uploads"
+                    )
+
+                # Upload-Defer-Length is also forbidden for final uploads
+                if upload_defer_length is not None:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="Upload-Defer-Length header must not be included for final concatenated uploads"
+                    )
+            else:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Invalid Upload-Concat header value"
+                )
+
         # create upload params
         params = TusUploadParams(
             metadata=metadata,
-            size=upload_length,
+            size=final_size,
             offset=0,
             upload_part=0,
             created_at=str(datetime.now()),
             defer_length=upload_defer_length is not None,
             expires=str(date_expiry.isoformat()),
+            is_partial=is_partial,
+            is_final=is_final,
+            partial_uploads=partial_uploads,
         )
 
         # run pre-create hook before creating the file
@@ -99,6 +228,74 @@ def creation_extension_routes(router, options):
             uid = file_result.get("uid", None)
         # create the file
         file = TusUploadFile(options=file_options, uid=uid, params=params)
+
+        # If this is a final concatenated upload, perform the concatenation
+        if is_final and partial_files:
+            final_path = file.path
+            bytes_written = 0
+
+            try:
+                # Concatenate all partial files into the final file using chunked copying
+                # This prevents memory issues with large files (e.g., 100GB+)
+                CHUNK_SIZE = 5 * 1024 * 1024  # 5MB chunks
+
+                with open(final_path, "wb") as final_f:
+                    for partial_file in partial_files:
+                        partial_path = partial_file.path
+
+                        # Copy file in chunks to avoid loading entire file into memory
+                        with open(partial_path, "rb") as partial_f:
+                            while True:
+                                chunk = partial_f.read(CHUNK_SIZE)
+                                if not chunk:
+                                    break
+                                final_f.write(chunk)
+                                bytes_written += len(chunk)
+
+                    # Ensure all data is written to disk before proceeding
+                    final_f.flush()
+                    os.fsync(final_f.fileno())
+
+                # Verify we wrote the expected amount of data
+                if bytes_written != final_size:
+                    raise Exception(
+                        f"Size mismatch after concatenation: expected {final_size}, wrote {bytes_written}"
+                    )
+
+                # Update the offset to indicate the upload is complete
+                params.offset = final_size
+                file.info = params
+
+                # Delete all partial uploads after successful concatenation
+                # Handle race conditions where partials might already be deleted
+                for partial_file in partial_files:
+                    try:
+                        partial_file.delete(partial_file.uid)
+                    except FileNotFoundError:
+                        # Partial already deleted (race condition or retry), ignore
+                        pass
+                    except Exception as delete_error:
+                        # Log but don't fail the concat - final file is already good
+                        import logging
+                        logger = logging.getLogger(__name__)
+                        logger.warning(
+                            f"Failed to delete partial {partial_file.uid}: {delete_error}"
+                        )
+
+            except Exception as e:
+                # Clean up the final file if concatenation fails
+                # This ensures we don't leave corrupted files around
+                try:
+                    if file.exists:
+                        file.delete(file.uid)
+                except Exception:
+                    pass  # Best effort cleanup
+
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Failed to concatenate uploads: {str(e)}"
+                )
+
         # update request headers
         response.headers["Location"] = get_request_headers(
             request=request, uuid=file.uid, prefix=options.prefix
@@ -107,8 +304,8 @@ def creation_extension_routes(router, options):
         response.headers["Content-Length"] = str(0)
         # set status code
         response.status_code = status.HTTP_201_CREATED
-        # run completion hooks
-        if file.info is not None and file.info.size == 0:
+        # run completion hooks for zero-byte uploads OR final concatenated uploads
+        if file.info is not None and (file.info.size == 0 or (is_final and file.info.offset == file.info.size)):
             file_path = os.path.join(file_options.files_dir, file.uid)
             result = on_complete(file_path, file.info.metadata)
             # if the callback returned a coroutine, await it

--- a/src/tuspyserver/routes/creation.py
+++ b/src/tuspyserver/routes/creation.py
@@ -85,8 +85,9 @@ def creation_extension_routes(router, options):
         result = pre_create(metadata, upload_info)
         # if the callback returned a coroutine, await it
         if inspect.isawaitable(result):
-            await result
-
+            result = await result
+        if isinstance(result, dict):
+            options.files_dir = result.get("files_dir", options.files_dir)
         # create the file
         file = TusUploadFile(options=options, params=params)
         # update request headers

--- a/src/tuspyserver/routes/termination.py
+++ b/src/tuspyserver/routes/termination.py
@@ -1,9 +1,37 @@
 from copy import deepcopy
 from typing import Callable
-from fastapi import Depends, HTTPException, Response, status
-import inspect 
+from fastapi import Depends, Header, HTTPException, Response, status
+import inspect
+import datetime
+from email.utils import parsedate_to_datetime
 
 from tuspyserver.file import TusUploadFile
+
+
+def _check_upload_expired(file: TusUploadFile) -> bool:
+    """Check if upload has expired and return True if expired."""
+    if not file.info or not file.info.expires:
+        return False
+    
+    expires_dt = None
+    if isinstance(file.info.expires, str):
+        try:
+            # Try RFC 7231 format first (e.g., "Mon, 02 Jan 2006 15:04:05 GMT")
+            expires_dt = parsedate_to_datetime(file.info.expires)
+        except (ValueError, TypeError):
+            # Fallback to ISO format
+            try:
+                expires_dt = datetime.datetime.fromisoformat(file.info.expires.replace('Z', '+00:00'))
+            except (ValueError, AttributeError):
+                return False
+    elif isinstance(file.info.expires, (int, float)):
+        expires_dt = datetime.datetime.fromtimestamp(file.info.expires)
+    
+    if expires_dt:
+        now = datetime.datetime.now(expires_dt.tzinfo) if expires_dt.tzinfo else datetime.datetime.now()
+        return expires_dt < now
+    
+    return False
 
 
 def termination_extension_routes(router, options):
@@ -13,9 +41,20 @@ def termination_extension_routes(router, options):
 
     @router.delete("/{uuid}", status_code=status.HTTP_204_NO_CONTENT)
     async def extension_termination_route(
-        uuid: str, response: Response, _=Depends(options.auth),
+        uuid: str,
+        response: Response,
+        tus_resumable: str = Header(None),
+        _=Depends(options.auth),
         file_dep: Callable[[dict], None] = Depends(options.file_dep),
     ) -> Response:
+        # Validate Tus-Resumable header version
+        if tus_resumable is None or tus_resumable != options.tus_version:
+            raise HTTPException(
+                status_code=status.HTTP_412_PRECONDITION_FAILED,
+                detail=f"Unsupported version. Expected {options.tus_version}",
+                headers={"Tus-Version": options.tus_version}
+            )
+        
         # Create a copy of options to avoid mutating the original
         file_options = deepcopy(options)
         result = file_dep({})
@@ -30,6 +69,10 @@ def termination_extension_routes(router, options):
         # Check if the upload ID is valid
         if not file.exists:
             raise HTTPException(status_code=404, detail="Upload not found")
+        
+        # Check if upload has expired (distinguish from non-existent uploads)
+        if file.info and _check_upload_expired(file):
+            raise HTTPException(status_code=status.HTTP_410_GONE, detail="Upload expired")
 
         # Delete the file and metadata for the upload from the mapping
         file.delete(uuid)

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,0 +1,72 @@
+import os
+import time
+
+import pytest
+
+from tuspyserver.lock import (
+    DEFAULT_LOCK_TIMEOUT,
+    FileLock,
+    LockTimeoutError,
+    acquire_upload_lock,
+)
+
+
+def test_lock_basic_acquire_release(tmp_path):
+    upload = tmp_path / "u1"
+    upload.write_bytes(b"")
+    with acquire_upload_lock(str(upload), locks_dir=str(tmp_path / ".locks")):
+        pass
+    # lock file should be cleaned up
+    assert not (tmp_path / ".locks" / "u1.lock").exists()
+
+
+def test_lock_times_out_when_held(tmp_path):
+    upload = tmp_path / "u2"
+    upload.write_bytes(b"")
+    locks = str(tmp_path / ".locks")
+    holder = FileLock(str(upload), locks_dir=locks)
+    holder.acquire(blocking=True)
+    try:
+        contender = FileLock(str(upload), locks_dir=locks)
+        start = time.monotonic()
+        with pytest.raises(LockTimeoutError):
+            contender.acquire(blocking=True, timeout=0.5)
+        elapsed = time.monotonic() - start
+        assert 0.4 <= elapsed < 2.0
+    finally:
+        holder.release()
+
+
+def test_lock_non_blocking_returns_false(tmp_path):
+    upload = tmp_path / "u3"
+    upload.write_bytes(b"")
+    locks = str(tmp_path / ".locks")
+    holder = FileLock(str(upload), locks_dir=locks)
+    holder.acquire(blocking=True)
+    try:
+        contender = FileLock(str(upload), locks_dir=locks)
+        assert contender.acquire(blocking=False) is False
+    finally:
+        holder.release()
+
+
+def test_lock_best_effort_when_dir_unwritable(tmp_path):
+    # Make a read-only locks dir parent so makedirs/open fails with EACCES
+    ro_root = tmp_path / "ro"
+    ro_root.mkdir()
+    locks = ro_root / ".locks"
+    upload = tmp_path / "u4"
+    upload.write_bytes(b"")
+    os.chmod(ro_root, 0o500)  # r-x: cannot create children
+    try:
+        lock = FileLock(str(upload), locks_dir=str(locks))
+        # Should NOT raise; falls back to best-effort.
+        assert lock.acquire(blocking=True, timeout=0.5) is True
+        assert lock.get_fd() is None
+        lock.release()  # must not raise
+    finally:
+        os.chmod(ro_root, 0o700)
+
+
+def test_default_timeout_is_bounded():
+    assert DEFAULT_LOCK_TIMEOUT < 120

--- a/tests/test_resume_pause.py
+++ b/tests/test_resume_pause.py
@@ -1,0 +1,388 @@
+"""
+Comprehensive tests for TUS protocol resume/pause functionality.
+
+These tests simulate real-world scenarios including:
+- Basic upload flow
+- Pause and resume with multiple chunks
+- Large file uploads
+- Network interruptions
+- Offset validation
+"""
+import os
+import tempfile
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from tuspyserver import create_tus_router
+
+
+class TestTusResumePause:
+    """Test TUS protocol resume and pause functionality."""
+
+    @pytest.fixture
+    def temp_dir(self) -> Generator[str, None, None]:
+        """Create a temporary directory for uploads."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield tmpdir
+
+    @pytest.fixture
+    def app(self, temp_dir: str) -> FastAPI:
+        """Create a FastAPI app with TUS router."""
+        app = FastAPI()
+
+        # Track completed uploads for testing
+        app.state.completed_uploads = []
+
+        def on_complete_sync(file_path: str, metadata: dict) -> None:
+            """Track completed uploads (synchronous version)."""
+            app.state.completed_uploads.append({
+                "file_path": file_path,
+                "metadata": metadata
+            })
+
+        router = create_tus_router(
+            prefix="/files",
+            files_dir=temp_dir,
+            max_size=100 * 1024 * 1024,  # 100 MB
+            on_upload_complete=on_complete_sync,
+            strict_offset_validation=True,  # Enable strict validation
+        )
+
+        app.include_router(router)
+        return app
+
+    @pytest.fixture
+    def client(self, app: FastAPI) -> TestClient:
+        """Create a test client."""
+        return TestClient(app)
+
+    @pytest.fixture
+    def large_file_content(self) -> bytes:
+        """Generate large file content (10 MB)."""
+        # Create 10 MB of data with a pattern for verification
+        chunk = b"A" * 1024  # 1 KB
+        return chunk * 10 * 1024  # 10 MB
+
+    def create_upload(
+        self,
+        client: TestClient,
+        filename: str,
+        file_size: int,
+        file_type: str = "audio/wav"
+    ) -> tuple[str, dict]:
+        """
+        Helper to create a new TUS upload.
+
+        Returns:
+            Tuple of (upload_id, headers)
+        """
+        import base64
+
+        # Encode metadata
+        metadata_parts = [
+            f"filename {base64.b64encode(filename.encode()).decode()}",
+            f"filetype {base64.b64encode(file_type.encode()).decode()}",
+        ]
+
+        response = client.post(
+            "/files",
+            headers={
+                "Upload-Length": str(file_size),
+                "Upload-Metadata": ", ".join(metadata_parts),
+                "Tus-Resumable": "1.0.0",
+            },
+        )
+
+        assert response.status_code == 201, f"Failed to create upload: {response.text}"
+        location = response.headers["Location"]
+        upload_id = location.split("/")[-1]
+
+        return upload_id, response.headers
+
+    def upload_chunk(
+        self,
+        client: TestClient,
+        upload_id: str,
+        chunk: bytes,
+        offset: int,
+        expected_status: int = 204
+    ) -> dict:
+        """
+        Helper to upload a chunk of data.
+
+        Returns:
+            Response headers (lowercase keys for consistency)
+        """
+        response = client.patch(
+            f"/files/{upload_id}",
+            content=chunk,
+            headers={
+                "Upload-Offset": str(offset),
+                "Content-Type": "application/offset+octet-stream",
+                "Content-Length": str(len(chunk)),
+                "Tus-Resumable": "1.0.0",
+            },
+        )
+
+        assert response.status_code == expected_status, \
+            f"Expected {expected_status}, got {response.status_code}: {response.text}"
+
+        # Convert headers to lowercase for consistent access
+        return {k.lower(): v for k, v in response.headers.items()}
+
+    def get_upload_info(self, client: TestClient, upload_id: str) -> dict:
+        """
+        Get upload information via HEAD request.
+
+        Returns:
+            Response headers (lowercase keys for consistency)
+        """
+        response = client.head(
+            f"/files/{upload_id}",
+            headers={"Tus-Resumable": "1.0.0"},
+        )
+
+        assert response.status_code == 200, f"Failed to get upload info: {response.text}"
+        # Convert headers to lowercase for consistent access
+        return {k.lower(): v for k, v in response.headers.items()}
+
+    def test_basic_upload_flow(self, client: TestClient):
+        """Test basic upload without interruption."""
+        # Create upload
+        file_content = b"Hello, World!"
+        upload_id, _ = self.create_upload(
+            client, "test.txt", len(file_content), "text/plain"
+        )
+
+        # Upload in one chunk
+        headers = self.upload_chunk(client, upload_id, file_content, 0)
+
+        # Verify upload completed
+        assert int(headers["upload-offset"]) == len(file_content)
+
+    def test_resume_after_pause(self, client: TestClient):
+        """Test resuming upload after pause (simulated)."""
+        # Create a 1MB file
+        file_content = b"X" * (1024 * 1024)
+        upload_id, _ = self.create_upload(client, "large.bin", len(file_content))
+
+        # Upload first chunk (500KB)
+        chunk_size = 500 * 1024
+        chunk1 = file_content[:chunk_size]
+        headers = self.upload_chunk(client, upload_id, chunk1, 0)
+        assert int(headers["upload-offset"]) == chunk_size
+
+        # Simulate pause - get current offset
+        info = self.get_upload_info(client, upload_id)
+        current_offset = int(info["upload-offset"])
+        assert current_offset == chunk_size
+
+        # Resume - upload remaining data
+        chunk2 = file_content[chunk_size:]
+        headers = self.upload_chunk(client, upload_id, chunk2, current_offset)
+        assert int(headers["upload-offset"]) == len(file_content)
+
+    def test_multiple_resume_cycles(self, client: TestClient):
+        """Test multiple pause/resume cycles."""
+        # Create a 2MB file
+        file_content = b"Y" * (2 * 1024 * 1024)
+        upload_id, _ = self.create_upload(client, "multi.bin", len(file_content))
+
+        # Upload in 4 chunks of 512KB each (totaling 2MB)
+        chunk_size = 512 * 1024
+        offset = 0
+        num_chunks = 4
+
+        for i in range(num_chunks):
+            start = i * chunk_size
+            end = min(start + chunk_size, len(file_content))
+            chunk = file_content[start:end]
+
+            # Verify current offset before uploading
+            if i > 0:
+                info = self.get_upload_info(client, upload_id)
+                assert int(info["upload-offset"]) == offset
+
+            # Upload chunk
+            headers = self.upload_chunk(client, upload_id, chunk, offset)
+            offset += len(chunk)
+            assert int(headers["upload-offset"]) == offset
+
+        # Verify final upload
+        assert offset == len(file_content)
+
+    def test_offset_mismatch_rejected(self, client: TestClient):
+        """Test that mismatched offsets are rejected with strict validation."""
+        file_content = b"Z" * (1024 * 1024)
+        upload_id, _ = self.create_upload(client, "offset.bin", len(file_content))
+
+        # Upload first chunk
+        chunk_size = 500 * 1024
+        chunk1 = file_content[:chunk_size]
+        self.upload_chunk(client, upload_id, chunk1, 0)
+
+        # Try to upload with wrong offset - should fail with 409 Conflict
+        chunk2 = file_content[chunk_size:]
+        wrong_offset = chunk_size + 100  # Incorrect offset
+
+        response = client.patch(
+            f"/files/{upload_id}",
+            content=chunk2,
+            headers={
+                "Upload-Offset": str(wrong_offset),
+                "Content-Type": "application/offset+octet-stream",
+                "Content-Length": str(len(chunk2)),
+                "Tus-Resumable": "1.0.0",
+            },
+        )
+
+        assert response.status_code == 409, \
+            "Expected 409 Conflict for offset mismatch"
+
+    def test_large_file_with_pauses(self, client: TestClient, large_file_content: bytes):
+        """Test uploading a large file with multiple pauses."""
+        file_size = len(large_file_content)
+        upload_id, _ = self.create_upload(client, "large_audio.wav", file_size)
+
+        # Upload in chunks with pauses between
+        chunk_size = 1024 * 1024  # 1 MB chunks
+        offset = 0
+
+        while offset < file_size:
+            # Get current offset
+            if offset > 0:
+                info = self.get_upload_info(client, upload_id)
+                current_offset = int(info["upload-offset"])
+                assert current_offset == offset, \
+                    f"Offset mismatch: expected {offset}, got {current_offset}"
+
+            # Upload next chunk
+            end = min(offset + chunk_size, file_size)
+            chunk = large_file_content[offset:end]
+            headers = self.upload_chunk(client, upload_id, chunk, offset)
+
+            offset = int(headers["upload-offset"])
+
+        # Verify complete upload
+        assert offset == file_size
+
+    def test_resume_after_network_interruption(
+        self, client: TestClient, app: FastAPI, temp_dir: str
+    ):
+        """Test resuming after simulated network interruption."""
+        file_content = b"N" * (5 * 1024 * 1024)  # 5 MB
+        upload_id, _ = self.create_upload(client, "interrupted.bin", len(file_content))
+
+        # Upload first part
+        chunk1_size = 2 * 1024 * 1024  # 2 MB
+        chunk1 = file_content[:chunk1_size]
+        self.upload_chunk(client, upload_id, chunk1, 0)
+
+        # Simulate server restart by creating new client (simulates connection loss)
+        # The file and metadata should persist
+        new_client = TestClient(app)
+
+        # Check that upload state was preserved
+        info = self.get_upload_info(new_client, upload_id)
+        assert int(info["upload-offset"]) == chunk1_size
+        assert int(info["upload-length"]) == len(file_content)
+
+        # Resume upload with new client
+        chunk2 = file_content[chunk1_size:]
+        headers = self.upload_chunk(new_client, upload_id, chunk2, chunk1_size)
+        assert int(headers["upload-offset"]) == len(file_content)
+
+    def test_concurrent_chunk_uploads(self, client: TestClient):
+        """Test that sequential chunks work correctly (no concurrent support)."""
+        file_content = b"C" * (2 * 1024 * 1024)
+        upload_id, _ = self.create_upload(client, "sequential.bin", len(file_content))
+
+        # Upload chunks sequentially
+        chunk_size = 1024 * 1024
+
+        # First chunk
+        chunk1 = file_content[:chunk_size]
+        headers1 = self.upload_chunk(client, upload_id, chunk1, 0)
+        assert int(headers1["upload-offset"]) == chunk_size
+
+        # Second chunk
+        chunk2 = file_content[chunk_size:]
+        headers2 = self.upload_chunk(client, upload_id, chunk2, chunk_size)
+        assert int(headers2["upload-offset"]) == len(file_content)
+
+    def test_zero_byte_file(self, client: TestClient):
+        """Test uploading an empty file."""
+        upload_id, _ = self.create_upload(client, "empty.txt", 0, "text/plain")
+
+        # For zero-byte files, no PATCH is needed according to TUS spec
+        # Just verify the upload exists
+        info = self.get_upload_info(client, upload_id)
+        assert int(info["upload-length"]) == 0
+        assert int(info["upload-offset"]) == 0
+
+    def test_file_integrity_after_resume(
+        self, client: TestClient, app: FastAPI, temp_dir: str
+    ):
+        """Test that file content is correct after multiple resumes."""
+        # Create file with recognizable pattern
+        pattern = b"ABCDEFGHIJ"
+        file_content = pattern * (100 * 1024)  # ~1MB with pattern
+
+        upload_id, _ = self.create_upload(client, "pattern.bin", len(file_content))
+
+        # Upload in 3 chunks
+        chunk1 = file_content[:300 * 1024]
+        chunk2 = file_content[300 * 1024:700 * 1024]
+        chunk3 = file_content[700 * 1024:]
+
+        self.upload_chunk(client, upload_id, chunk1, 0)
+        self.upload_chunk(client, upload_id, chunk2, len(chunk1))
+        self.upload_chunk(client, upload_id, chunk3, len(chunk1) + len(chunk2))
+
+        # Verify file content
+        file_path = Path(temp_dir) / upload_id
+        assert file_path.exists()
+
+        with open(file_path, "rb") as f:
+            uploaded_content = f.read()
+
+        assert uploaded_content == file_content, "File content mismatch after resume"
+
+    def test_upload_completion_callback(
+        self, client: TestClient, app: FastAPI
+    ):
+        """Test that completion callback is called correctly."""
+        file_content = b"Callback test content"
+        upload_id, _ = self.create_upload(
+            client, "callback.txt", len(file_content), "text/plain"
+        )
+
+        # Upload complete file
+        self.upload_chunk(client, upload_id, file_content, 0)
+
+        # Verify callback was called
+        assert len(app.state.completed_uploads) == 1
+        completed = app.state.completed_uploads[0]
+        assert upload_id in completed["file_path"]
+        assert completed["metadata"]["filename"] == "callback.txt"
+
+    def test_options_endpoint(self, client: TestClient):
+        """Test OPTIONS endpoint returns correct TUS capabilities."""
+        response = client.options(
+            "/files/",
+            headers={"Tus-Resumable": "1.0.0"},
+        )
+
+        assert response.status_code == 204
+        assert "Tus-Version" in response.headers
+        assert "Tus-Extension" in response.headers
+        assert "Tus-Max-Size" in response.headers
+        assert "creation" in response.headers["Tus-Extension"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "tuspyserver"
-version = "4.1.6"
+version = "4.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "tuspyserver"
-version = "4.1.8"
+version = "4.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "tuspyserver"
-version = "4.1.2"
+version = "4.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "tuspyserver"
-version = "4.2.0"
+version = "4.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "tuspyserver"
-version = "4.1.5"
+version = "4.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "tuspyserver"
-version = "4.1.4"
+version = "4.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "tuspyserver"
-version = "4.1.7"
+version = "4.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "tuspyserver"
-version = "4.1.3"
+version = "4.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [manifest]
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "tuspyserver"
-version = "4.2.1"
+version = "4.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "tuspyserver"
-version = "4.1.9"
+version = "4.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "tuspyserver"
-version = "4.1.1"
+version = "4.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "tuspyserver"
-version = "4.2.3"
+version = "4.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- Bound flock acquisition with a configurable timeout (default 30s) instead of blocking forever
- Degrade to best-effort no-op lock when the locks dir is unwritable (EACCES/EROFS/ENOSPC), e.g. flapping Azure Files SMB mount
- Surface `LockTimeoutError` as 503 in the request handler so workers fail fast
- Bump 4.2.3 → 4.2.4

## Why
Prod incident 2026-04-29 02:37–04:27 UTC: all 3 API pods wedged simultaneously after `[Errno 13] Permission denied` writing `/mnt/azure/tus/.locks/...` on the shared Azure Files mount. `fcntl.flock(LOCK_EX)` blocked indefinitely; uvicorn workers piled up; nginx returned 503s for ~110 minutes until pods were rolled.

## Test plan
- [x] New tests under `tests/test_lock.py` (5 tests): basic acquire/release, timeout, non-blocking, best-effort fallback on unwritable dir, default-timeout sanity
- [x] All existing tests still pass (16/16)