### PR TITLE
ci: use trusted publishing for PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
     - name: Checkout code
@@ -20,7 +24,4 @@ jobs:
       run: uv build --package tuspyserver
 
     - name: Publish to PyPI
-      env:
-        UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       run: uv publish
-

--- a/README.md
+++ b/README.md
@@ -303,12 +303,21 @@ where the root is the [library](https://docs.astral.sh/uv/concepts/projects/init
 
 ### Releasing
 
+PyPI publishing uses [Trusted Publishing](https://docs.pypi.org/trusted-publishers/).
+Before the first release, add a GitHub Actions trusted publisher for the PyPI
+project with:
+
+- Owner: `edihasaj`
+- Repository name: `tuspyserver`
+- Workflow name: `publish.yml`
+- Environment name: `pypi`
+
 To release the package, follow the following steps:
 
 1. Update the version in `pyproject.toml` using [semver](https://semver.org/)
 2. Merge PR to main or push directly to main
 3. Open a PR to merge `main` → `production`.
-4. Upon merge, CI/CD will publish to PyPI.
+4. Upon merge, CI/CD will publish to PyPI without a PyPI API token secret.
 
 
 *© 2025 Edi Hasaj [X](https://x.com/hasajedi)*


### PR DESCRIPTION
## Summary
- switch PyPI publishing to GitHub OIDC trusted publishing
- document the PyPI trusted publisher fields for releases

## Verification
- uv build --package tuspyserver

Fixes #84